### PR TITLE
swap buffertools out for buffer-equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 "use strict";
 
 var assert = require('assert'),
-    bufferEqual = require('buffer-equal'),
+    bufferEqual = require('./lib/bufferEqual.js'),
     constants = require('./lib/constants.js'),
     crypto = require('crypto'),
     events = require('events'),

--- a/lib/bufferEqual.js
+++ b/lib/bufferEqual.js
@@ -1,0 +1,13 @@
+var Buffer = require('buffer').Buffer; // for use with browserify
+
+module.exports = function (a, b) {
+    if (!Buffer.isBuffer(a)) return undefined;
+    if (!Buffer.isBuffer(b)) return undefined;
+    if (a.length !== b.length) return false;
+    
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    
+    return true;
+};

--- a/package.json
+++ b/package.json
@@ -6,11 +6,8 @@
     "test": "node scripts/test.js"
   },
   "main": "index.js",
-  "dependencies": {
-    "buffer-equal": "0.0.0"
-  },
   "devDependencies": {
-    "nodeunit": "0.8.1"
+    "nodeunit": "0.8.x"
   },
   "repository": {
     "type": "git",

--- a/test/update.js
+++ b/test/update.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var KBucket = require('../index.js'),
-    bufferEqual = require('buffer-equal');
+    bufferEqual = require('../lib/bufferEqual.js');
 
 var test = module.exports = {};
 


### PR DESCRIPTION
buffertools requires a compilation step and does some questionable
things like touching the prototype of the Buffer class. buffer-equal is
much less intrusive, much less code, and much less (infinity less, in
fact) native code.
