### PR TITLE
switch hashing a timestamp to crypto.randomBytes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Kademlia DHT K-bucket implementation as a binary tree.
 var KBucket = require('k-bucket');
 
 var kBucket = new KBucket({
-    localNodeId: new Buffer("my node id") // default: random SHA-1
+    localNodeId: new Buffer("my node id") // default: random data
 });
 ```
 
@@ -67,7 +67,7 @@ Finds the XOR distance between firstId and secondId.
 #### new KBucket(options)
 
   * `options`:
-    * `localNodeId`: _String (base64)_ or _Buffer_ An optional String or a Buffer representing the local node id. If not provided, a local node id will be created via `crypto.createHash('sha1').update('' + new Date().getTime() + process.hrtime()[1]).digest()`. If a String is provided, it will be assumed to be base64 encoded and will be converted into a Buffer.
+    * `localNodeId`: _String (base64)_ or _Buffer_ An optional String or a Buffer representing the local node id. If not provided, a local node id will be created via `crypto.randomBytes(20)`. If a String is provided, it will be assumed to be base64 encoded and will be converted into a Buffer.
     * `root`: _Object_ _**CAUTION: reserved for internal use**_ Provides a reference to the root of the tree data structure as the k-bucket splits when new contacts are added.
 
 Creates a new KBucket.

--- a/index.js
+++ b/index.js
@@ -46,10 +46,7 @@ var KBucket = module.exports = function KBucket (options) {
     // the bucket array has least-recently-contacted at the "front/left" side
     // and the most-recently-contaced at the "back/right" side
     self.bucket = [];
-    self.localNodeId = options.localNodeId 
-        || crypto.createHash('sha1')
-            .update('' + new Date().getTime() + process.hrtime()[1])
-            .digest();
+    self.localNodeId = options.localNodeId || crypto.randomBytes(20);
     if (!(self.localNodeId instanceof Buffer)) {
         self.localNodeId = new Buffer(self.localNodeId, 'base64');
     }


### PR DESCRIPTION
the crypto.randomBytes() implementation is pretty much definitely going
to do a better job at randomness than a hashed timestamp, and might even
be faster to boot.
