### PR TITLE
Modified splitAndAdd to build new KBuckets with all proper options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kademlia DHT K-bucket implementation as a binary tree.
 
 ## Contributors
 
-[@tristanls](https://github.com/tristanls), [@mikedeboer](https://github.com/mikedeboer), [@deoxxa](https://github.com/deoxxa), [@feross](https://github.com/feross)
+[@tristanls](https://github.com/tristanls), [@mikedeboer](https://github.com/mikedeboer), [@deoxxa](https://github.com/deoxxa), [@feross](https://github.com/feross), [@nathanph](https://github.com/nathanph)
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -313,8 +313,20 @@ KBucket.prototype.remove = function remove (contact, bitIndex) {
 //          binary tree
 KBucket.prototype.splitAndAdd = function splitAndAdd (contact, bitIndex) {
     var self = this;
-    self.low = new KBucket({localNodeId: self.localNodeId, root: self.root});
-    self.high = new KBucket({localNodeId: self.localNodeId, root: self.root});
+    self.low = new KBucket({
+        arbiter: self.arbiter,
+        localNodeId: self.localNodeId,
+        root: self.root,
+        numberOfNodesPerKBucket: self.numberOfNodesPerKBucket,
+        numberOfNodesToPing: self.numberOfNodesToPing
+    });
+    self.high = new KBucket({
+        arbiter: self.arbiter,
+        localNodeId: self.localNodeId,
+        root: self.root,
+        numberOfNodesPerKBucket: self.numberOfNodesPerKBucket,
+        numberOfNodesToPing: self.numberOfNodesToPing
+    });
 
     bitIndex = bitIndex || 0;
 


### PR DESCRIPTION
The function splitAndAdd did not pass all of its options onto the
children buckets. The new buckets now have arbiter,
numberOfNodesPerKBucket, and numberOfNodesToPing added to them along
with the previous options: localNodeId and root.