### PR TITLE
Use inherits module

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var assert = require('assert');
 var bufferEqual = require('buffer-equal');
 var crypto = require('crypto');
 var events = require('events');
-var util = require('util');
+var inherits = require('inherits');
 
 /*
   * `options`:
@@ -86,7 +86,7 @@ var KBucket = module.exports = function KBucket (options) {
     self.high = null;
 };
 
-util.inherits(KBucket, events.EventEmitter);
+inherits(KBucket, events.EventEmitter);
 
 KBucket.distance = function distance (firstId, secondId) {
     var max = Math.max(firstId.length, secondId.length);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "nodeunit": "0.9.x"
   },
   "dependencies": {
-    "buffer-equal": "0.0.1"
+    "buffer-equal": "0.0.1",
+    "inherits": "^2.0.1"
   },
   "repository": {
     "type": "git",

--- a/test/createKBucket.js
+++ b/test/createKBucket.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var bufferEqual = require('buffer-equal');
+var events = require('events');
 
 var KBucket = require('../index.js');
 
@@ -36,5 +37,12 @@ test['root is \'self\' if not provided'] = function (test) {
     test.expect(1);
     var kBucket = new KBucket();
     test.strictEqual(kBucket.root, kBucket);
+    test.done();
+};
+
+test['inherits from EventEmitter'] = function (test) {
+    test.expect(1);
+    var kBucket = new KBucket();
+    test.ok(kBucket instanceof events.EventEmitter);
     test.done();
 };


### PR DESCRIPTION
This makes the browserify build smaller and so more browser friendly, on node it just exports `util.inherits` still