### PR TITLE
Use buffer-equals instead buffer-equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 "use strict";
 
-var bufferEqual = require('buffer-equal');
+var bufferEquals = require('buffer-equals');
 var randomBytes = require('randombytes');
 
 /*
@@ -268,7 +268,7 @@ KBucket.prototype.get = function get (id, bitIndex) {
 KBucket.prototype.indexOf = function indexOf (contact) {
     var self = this;
     for (var i = 0; i < self.bucket.length; i++) {
-        if (bufferEqual(self.bucket[i].id, contact.id)) return i;
+        if (bufferEquals(self.bucket[i].id, contact.id)) return i;
     }
     return -1;
 };
@@ -379,7 +379,7 @@ KBucket.prototype.toArray = function toArray () {
 KBucket.prototype.update = function update (contact, index) {
     var self = this;
     // sanity check
-    if (!bufferEqual(self.bucket[index].id, contact.id)) {
+    if (!bufferEquals(self.bucket[index].id, contact.id)) {
         throw new Error("indexOf() calculation resulted in wrong index")
     }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nodeunit": "0.9.x"
   },
   "dependencies": {
-    "buffer-equal": "0.0.1",
+    "buffer-equals": "^1.0.3",
     "randombytes": "^2.0.3"
   },
   "repository": {


### PR DESCRIPTION
[buffer-equal](https://github.com/substack/node-buffer-equal/blob/76c6545022bf211eb6305d9c4b8c37628029f7f7/index.js#L3) not throwing `TypeError` if one of arguments is not `Buffer`, but node buffer equals does.
[buffer-equals](https://github.com/sindresorhus/buffer-equals/blob/7eff8317ce92d075db1bfa79cec2390ed273e5e7/index.js#L4) throwing `TypeError`