### PR TITLE
add lastChange property

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ Emitted when `contact` was removed from the bucket.
 
 Emitted when a previously existing ("previously existing" means `oldContact.id` equals `newContact.id`) contact was added to the bucket and it was replaced with `newContact`.
 
+#### Property: 'metadata'
+
+The `metadata` object serves as a container that can be used by implementations using k-bucket. One example is storing a timestamp to indicate the last time when a node in the bucket was responding to a ping.
+
 ## Releases
 
 [Current releases](https://github.com/tristanls/k-bucket/releases).

--- a/index.js
+++ b/index.js
@@ -73,6 +73,8 @@ function KBucket (options) {
   this.arbiter = options.arbiter || KBucket.arbiter
 
   this.root = createNode()
+
+  this.metadata = Object.assign({}, options.metadata)
 }
 
 inherits(KBucket, EventEmitter)


### PR DESCRIPTION
Hi! I'm improving bittorrent-dht's handling of node-lists and how it handles unresponsive nodes. 

This adds a `lastChange` property.

```
Each bucket should maintain a "last changed" property to indicate how "fresh" the 
contents  are. When a node in a bucket is pinged and it responds, or a node is added 
to a bucket, or a node in a bucket is replaced with another node, the bucket's last 
changed property should be updated. Buckets that have not been changed in 
15 minutes should be "refreshed."
```
from: http://www.bittorrent.org/beps/bep_0005.html#routing-table


The implementation / updates for the `lastChange` property should be done in "userland" as ping implementation is also handled there.