### PR TITLE
Faster `closest()` + benchmark

### DIFF
--- a/benchmarks/closest.js
+++ b/benchmarks/closest.js
@@ -1,0 +1,22 @@
+'use strict'
+
+var crypto = require('crypto')
+var KBucket = require('../')
+
+function getNextId () {
+  seed = crypto.createHash('sha256').update(seed).digest()
+  return seed
+}
+
+var seed = process.env.SEED || crypto.randomBytes(32).toString('hex')
+console.log('Seed: ' + seed)
+getNextId()
+var bucket = new KBucket()
+for (var j = 0; j < 1e4; ++j) bucket.add({ id: getNextId() })
+
+console.time('KBucket.closest')
+for (var i = 0; i < 1e4; i++) {
+  bucket.closest(seed, 10)
+}
+console.timeEnd('KBucket.closest')
+console.log('Memory: ', process.memoryUsage())

--- a/index.js
+++ b/index.js
@@ -181,10 +181,10 @@ KBucket.prototype.closest = function (id, n) {
     .sort(function (a, b) {
       return a[0] - b[0]
     })
+    .slice(0, n)
     .map(function (a) {
       return a[1]
     })
-    .slice(0, n)
 }
 
 // Counts the number of contacts recursively.

--- a/index.js
+++ b/index.js
@@ -174,11 +174,17 @@ KBucket.prototype.closest = function (id, n) {
   }
 
   var self = this
-  function compare (a, b) {
-    return self.distance(a.id, id) - self.distance(b.id, id)
-  }
-
-  return contacts.sort(compare).slice(0, n)
+  return contacts
+    .map(function (a) {
+      return [self.distance(a.id, id), a]
+    })
+    .sort(function (a, b) {
+      return a[0] - b[0]
+    })
+    .map(function (a) {
+      return a[1]
+    })
+    .slice(0, n)
 }
 
 // Counts the number of contacts recursively.


### PR DESCRIPTION
While simplification from previous PR made `closest()` significantly slower, this PR makes it more complex, but ~3x faster on my machine (benchmark also added) with a tiny bit higher memory consumption.

The idea is to make exactly `contacts.length` calls to `self.distance()`, which is relatively expensive. Previously much more `self.distance()` calls were made, exact number depended on the order of elements.

Before:
```
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: bdd0278dc6a64f7bc781a78f3b47aca9d927d74229e40e82f27e0af857df2873
KBucket.closest: 103.447ms
Memory:  { rss: 38739968,
  heapTotal: 11853824,
  heapUsed: 6907960,
  external: 14804 }
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: e1a713cbd7a2818f6b84efb0e13ea59530d0a3c35088875de0a082d506f2bb79
KBucket.closest: 96.945ms
Memory:  { rss: 38920192,
  heapTotal: 11853824,
  heapUsed: 6368960,
  external: 14996 }
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: b95d5f3cb1433f19f557f05d852a06e0685f4e0c9bb9e706730c535df4043bb8
KBucket.closest: 94.969ms
Memory:  { rss: 38813696,
  heapTotal: 11853824,
  heapUsed: 6412656,
  external: 15412 }
```
After:
```
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: 471cf7518dabb8e894d54a7500b5e96c0c3c93cd148ca297f7870733ab5db94b
KBucket.closest: 32.106ms
Memory:  { rss: 39079936,
  heapTotal: 11853824,
  heapUsed: 5460976,
  external: 14740 }
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: 21a844fbe3b3fc6cd5773759449db883d3ff6a641c1644484c237d69318fed2c
KBucket.closest: 34.007ms
Memory:  { rss: 39239680,
  heapTotal: 11853824,
  heapUsed: 5491544,
  external: 15060 }
nazar-pc@nazar-pc /w/g/k-bucket> node benchmarks/closest.js 
Seed: 8e93c42d96ce566f9e2d99b227458f46ecca707d17877fe0a6d1b00332eb634f
KBucket.closest: 34.597ms
Memory:  { rss: 39092224,
  heapTotal: 11853824,
  heapUsed: 7419152,
  external: 15060 }
```