### PR TITLE
fix: switch randombytes for iso-random-stream for browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 'use strict'
 
-const randomBytes = require('randombytes')
+const { randomBytes } = require('iso-random-stream')
 const { EventEmitter } = require('events')
 
 /**

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "unit": "tape test/*.js"
   },
   "dependencies": {
-    "randombytes": "^2.1.0"
+    "events": "^3.3.0",
+    "iso-random-stream": "^2.0.2"
   },
   "devDependencies": {
     "nyc": "^15.1.0",


### PR DESCRIPTION
The `randombytes` package depends on `safe-buffer` which uses the built-in `buffer` module from node core without declaring the polyfill as a dep.

If you have this installed accidentally as a dependency of another dep you will be fine but if not you'll see errors like this in the browser:

```
dex.js:12 Uncaught TypeError: Cannot read properties of undefined (reading 'from')
    at node_modules/safe-buffer/index.js (index.js:12:12)
    at __require2 (chunk-LFBQMW2U.js?v=930a8016:19:50)
    at node_modules/randombytes/browser.js (browser.js:15:14)
    at __require2 (chunk-LFBQMW2U.js?v=930a8016:19:50)
    at node_modules/k-bucket/index.js (index.js:31:21)
    at __require2 (chunk-LFBQMW2U.js?v=930a8016:19:50)
    at index.ts:2:19
```

This PR switches `randombytes` for `iso-random-stream` which does not have this problem and uses the native random bytes functionality in both node and browsers.

It also adds a dependency on the `events` polyfill in case you don't have that as a transitive dependency either.